### PR TITLE
Enable auto-scroll on the calls list page

### DIFF
--- a/frontend/src/client/Call/ListCalls.js
+++ b/frontend/src/client/Call/ListCalls.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react";
 import {Link} from 'react-router-dom';
 import CallItem from "./CallItem";
 import {
@@ -26,7 +26,12 @@ class ListCalls extends React.Component {
     super(props);
 
   }
-
+  
+  
+  //https://stackoverflow.com/questions/33188994/scroll-to-the-top-of-the-page-after-render-in-react-js
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
  
  
 

--- a/frontend/src/client/Call/ListCalls.js
+++ b/frontend/src/client/Call/ListCalls.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React from "react";
 import {Link} from 'react-router-dom';
 import CallItem from "./CallItem";
 import {
@@ -25,28 +25,28 @@ class ListCalls extends React.Component {
   constructor(props) {
     super(props);
 
+    // Ref for auto-scrolling
+    this.headerRef = React.createRef();
+    this.windowPos = 0;
   }
-  
-  
-  //https://stackoverflow.com/questions/33188994/scroll-to-the-top-of-the-page-after-render-in-react-js
-  useEffect(() => {
-    window.scrollTo(0, 0)
-  }, [])
- 
- 
+
+  componentDidMount() {
+    if (this.windowPos === 0) {
+      // If the user hasn't scrolled down intentionally, scroll up to the top of the page
+      this.headerRef.current.scrollTo(0, 0);
+    }
+  }
 
   //https://stackoverflow.com/questions/36559661/how-can-i-dispatch-from-child-components-in-react-redux
   //https://stackoverflow.com/questions/42597602/react-onclick-pass-event-with-parameter
   render() {
-
-
-  
-   
+    // Capture window position
+    this.windowPos = window.scrollY;
    
     return (
 
         <Table id="calls" unstackable>
-          <Table.Header >
+          <Table.Header ref={this.headerRef}>
             <Table.Row>
               <Table.HeaderCell>Len</Table.HeaderCell>
               <Table.HeaderCell>Talkgroup</Table.HeaderCell>


### PR DESCRIPTION
The intent of this PR is to enable auto-scrolling on the calls list page when new calls come in.

I am not quite sure how to test this, as I imagine this would require running a local server _and_ have new calls come in. If you have any suggestions or directions for that I'm happy to hear them!

(Also this is my first contribution to a React app so apologies if this includes something egregiously non-idiomatic :slightly_smiling_face: )

Resolves #2 