### PR TITLE
Sort

### DIFF
--- a/frontend/src/client/Call/CallInfo.js
+++ b/frontend/src/client/Call/CallInfo.js
@@ -29,7 +29,7 @@ class CallInfo extends React.Component {
       var time = new Date(currentCall.time);
       callTime = time.toLocaleTimeString();
       callDate = time.toLocaleDateString();
-      time.setSeconds(currentCall.time.getSeconds() + currentCall.len);
+      time.setSeconds(time.getSeconds() + currentCall.len);
       callEndTime = time.toLocaleTimeString();
 
       if (currentCall.freq) {

--- a/frontend/src/client/Call/CallInfo.js
+++ b/frontend/src/client/Call/CallInfo.js
@@ -22,12 +22,16 @@ class CallInfo extends React.Component {
     var callFreq = "-";
     var callDate = "-";
     var callTime = "-";
+    var callEndTime = "-";
     var talkgroupNum = "-";
     if (this.props.call) {
       const currentCall = this.props.call;
       var time = new Date(currentCall.time);
       callTime = time.toLocaleTimeString();
       callDate = time.toLocaleDateString();
+      time.setSeconds(currentCall.time.getSeconds() + currentCall.len);
+      callEndTime = time.toLocaleTimeString();
+
       if (currentCall.freq) {
         var freq = currentCall.freq / 1000000;
         callFreq = Math.round(freq * 1000) / 1000;
@@ -61,7 +65,7 @@ class CallInfo extends React.Component {
           <List.Item>
             <Icon name="wait"/>
             <List.Content>
-              {callTime}
+              {callTime} ({callEndTime})
             </List.Content>
           </List.Item>
           <List.Item>

--- a/frontend/src/client/Call/CallItem.js
+++ b/frontend/src/client/Call/CallItem.js
@@ -71,6 +71,7 @@ showStar() {
 render() {
   const call = this.props.call;
   const time = new Date(call.time);
+  time.setSeconds(time.getSeconds() + call.len);
   const current = new Date(time).setHours(0, 0, 0, 0);
   var rowSelected={};
   let starButton;

--- a/frontend/src/client/Call/call-reducer.js
+++ b/frontend/src/client/Call/call-reducer.js
@@ -21,6 +21,17 @@ import {
   ADD_STAR_SUCCESS
 } from "./call-constants";
 
+function getCallSorter(byId) {
+  return (a, b) => {
+    const timeA = new Date(byId[a].time);
+    timeA.setSeconds(timeA.getSeconds() + byId[a].len);
+    const timeB = new Date(byId[b].time);
+    timeB.setSeconds(timeB.getSeconds() + byId[b].len);
+
+    return timeB - timeA;
+  };
+}
+
 function updateObject(oldObject, newValues) {
     // Encapsulate the idea of passing a new object as the first parameter
     // to Object.assign to ensure we correctly copy data instead of mutating
@@ -156,14 +167,14 @@ const call = (
   case FETCH_SUCCESS_CALL:
   {
       const byId = action.data.calls.reduce((acc, call) => ({ ...acc, [call._id]: call }), {});
-      const allIds =  action.data.calls.map(call => call._id);
+      const allIds = [...(action.data.calls.map(call => call._id))].sort(getCallSorter(byId));
       return Object.assign({}, state, {
           isWaiting: false,
           shortName: action.data.shortName,
           newestCallTime: new Date(action.data.calls[0].time),
           oldestCallTime: new Date(action.data.calls[action.data.calls.length-1].time),
           byId:  { ...byId},
-          allIds: [...allIds]
+          allIds
         });
     }
 

--- a/frontend/src/client/Call/call-reducer.js
+++ b/frontend/src/client/Call/call-reducer.js
@@ -202,7 +202,7 @@ const call = (
 // This will add the array of Calls in the data to the beginning of the existing array of Calls
     case FETCH_SUCCESS_NEWER_CALL:
     const byId = action.data.calls.reduce((acc, call) => ({ ...acc, [call._id]: call }), {});
-    const allIds = [...(action.data.calls.map(call => call._id))].sort(getCallSorter(byId));
+    const allIds = [...(action.data.calls.map(call => call._id).reverse())].sort(getCallSorter(byId));
 
     return Object.assign({}, state, {
         isWaiting: false,

--- a/frontend/src/client/Call/call-reducer.js
+++ b/frontend/src/client/Call/call-reducer.js
@@ -202,7 +202,8 @@ const call = (
 // This will add the array of Calls in the data to the beginning of the existing array of Calls
     case FETCH_SUCCESS_NEWER_CALL:
     const byId = action.data.calls.reduce((acc, call) => ({ ...acc, [call._id]: call }), {});
-    const allIds =  action.data.calls.map(call => call._id).reverse();
+    const allIds = [...(action.data.calls.map(call => call._id))].sort(getCallSorter(byId));
+
     return Object.assign({}, state, {
         isWaiting: false,
         shortName: action.data.shortName,
@@ -215,7 +216,7 @@ const call = (
     case FETCH_SUCCESS_OLDER_CALL:
     {
     const byId = action.data.calls.reduce((acc, call) => ({ ...acc, [call._id]: call }), {});
-    const allIds =  action.data.calls.map(call => call._id);
+    const allIds = [...(action.data.calls.map(call => call._id))].sort(getCallSorter(byId));
     return Object.assign({}, state, {
         isWaiting: false,
         shortName: action.data.shortName,


### PR DESCRIPTION
There are weird quirks with the current experience. Because of the nature of a socket being used as an upserted data stream and the start date of the recording being the sort key, a sort of race condition occurs. Items end up disarranged.

For example, a call starts at **1:00PM**🔵  and another at **1:02PM**🔴.

The call starting at **1:02PM**🔴 ends at 1:03PM and it's uploaded. Socket clients upsert this entry.

The call starting at **1:00PM**🔵 ends at 1:04PM. Same events happen and call A ends up at the top.

| Name  | Start date   |
|--------|---------|
| Call 🔵 | 1:00PM  |
| Call 🔴 | 1:02PM  |
| Call 🟡  | 12:58PM |

Now the list is not perfectly sorted. If you let a bunch pile on, it gets messy.

If we fix it with sorting, then we get a weird scenario where new calls don't always go to the top. They might be inserted somewhere else. You could mark new calls to help make them discoverable but that's still not a polish solution.

## A 'Sweet Spot' Solution

If we sort by call end time, this is instantly remedy. New calls continue to get upserted and but we don't need to worry about the order not being preserved. The time shown in the list would have to change. But we can keep the start time in the description.

Optimally you would change the schema to have this field in the database. Maybe if there's an existing created date then you could use that. But for now, this solution does it all via 'upload time' + 'call length'. We just have to sort the initial, newer and older fetch calls.