### PR TITLE
Fix admin client variables

### DIFF
--- a/admin/src/client/System/System.js
+++ b/admin/src/client/System/System.js
@@ -33,11 +33,6 @@ function planName(planType) {
   }
 }
 
-var backend_server =
-  process.env["BACKEND_SERVER"] != null
-    ? process.env["BACKEND_SERVER"]
-    : "https://api.openmhz.com";
-
 class System extends Component {
   constructor(props) {
     super(props);

--- a/admin/src/client/components/pure/About.js
+++ b/admin/src/client/components/pure/About.js
@@ -1,9 +1,6 @@
 import React, { Component } from "react";
 import { Container, Header } from "semantic-ui-react";
 
-var site_name = process.env['SITE_NAME'] != null ? process.env['SITE_NAME'] : "OpenMHz";
-var admin_email = process.env['ADMIN_EMAIL'] != null ? process.env['ADMIN_EMAIL'] : "luke@openmhz.com";
-
 class About extends Component {
 
 

--- a/admin/src/client/components/pure/Navigation.js
+++ b/admin/src/client/components/pure/Navigation.js
@@ -8,8 +8,6 @@ const navStyle = {
 const blankStyle = {
   marginBottom: "50px"
 };
-var account_server = process.env['ACCOUNT_SERVER'] != null ? process.env['ACCOUNT_SERVER'] : 'https://account.openmhz.com';
-var site_name = process.env['SITE_NAME'] != null ? process.env['SITE_NAME'] : "OpenMHz";
 
 class Navigation extends Component {
   constructor(props) {

--- a/admin/src/server/index.js
+++ b/admin/src/server/index.js
@@ -132,6 +132,7 @@ function isLoggedIn(req, res, next) {
 
 
 var admin_server = process.env['ADMIN_SERVER'] != null ? process.env['ADMIN_SERVER'] : 'https://admin.openmhz.com';
+var admin_email = process.env['ADMIN_EMAIL'] != null ? process.env['ADMIN_EMAIL'] : "luke@openmhz.com";
 var beta_frontend_server = process.env['BETA_FRONTEND_SERVER'] != null ? process.env['BETA_FRONTEND_SERVER'] : 'https://beta.openmhz.com';
 var backend_server = process.env['BACKEND_SERVER'] != null ? process.env['BACKEND_SERVER'] : 'https://api.openmhz.com';
 var frontend_server = process.env['FRONTEND_SERVER'] != null ? process.env['FRONTEND_SERVER'] : 'https://openmhz.com';
@@ -189,6 +190,8 @@ app.get("*", (req, res, next) => {
       const media_server = "${media_server}";
       const socket_server = "${socket_server}";
       const account_server = "${account_server}";
+      const site_name = "${site_name}";
+      const admin_email = "${admin_email}";
 			const proPlanValue = ${proPlanValue};
 			const freePlanValue = ${freePlanValue};
     </script>

--- a/frontend/src/client/Main/Main.js
+++ b/frontend/src/client/Main/Main.js
@@ -53,8 +53,6 @@ const HomepageHeading = ({ mobile }) => (
   </Container>
 )
 
-var site_name = process.env['SITE_NAME'] != null ? process.env['SITE_NAME'] : "OpenMHz";
-
 /*
 HomepageHeading.propTypes = {
   mobile: PropTypes.bool,

--- a/frontend/src/server/index.js
+++ b/frontend/src/server/index.js
@@ -71,6 +71,7 @@ app.get("*", (req, res, next) => {
 			const freePlanValue = ${freePlanValue};
 			const proPlanArchive = ${proPlanArchive};
 			const freePlanArchive = ${freePlanArchive};
+			const site_name = "${site_name}";
 		</script>
 		<script src="${backend_server}/socket.io/socket.io.js"></script>
 		<script>


### PR DESCRIPTION
In the admin interface, the site name always shows as OpenMHz, and Profile link always goes to account.openmhz.com. This is because the frontend code doesn't have access to the env variables; pass them in from the admin server side instead.