### PR TITLE
Update MongoDB Driver

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "find-remove": "1.0.1",
     "get-folder-size": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "mongodb": "2.2.31",
+    "mongodb": "2.2.36",
     "mongoose": "5.3.12",
     "multer": "1.3.0",
     "node-ffprobe": "github:ListenerApproved/node-ffprobe",


### PR DESCRIPTION
Without this, the 'errors' stats function will fail with newer versions of MongoDB server.