### PR TITLE
add searching to filtermodal dropdowns

### DIFF
--- a/frontend/src/Call/components/FilterModal.js
+++ b/frontend/src/Call/components/FilterModal.js
@@ -106,7 +106,7 @@ function FilterModal(props) {
       menuItem: 'Groups', render: () => {
         return (
           <Tab.Pane attached={false}>
-            <Dropdown placeholder='Groups' fluid selection options={groupList} value={selectedGroup} name='selectedGroup' onChange={handleGroupChange} />
+            <Dropdown placeholder='Groups' fluid search selection options={groupList} value={selectedGroup} name='selectedGroup' onChange={handleGroupChange} />
 
           </Tab.Pane>
         )
@@ -116,7 +116,7 @@ function FilterModal(props) {
       menuItem: 'Talkgroups', render: () => {
         return (
           <Tab.Pane attached={false}>
-            <Dropdown placeholder='Talkgroups' fluid multiple selection options={talkgroupList} value={selectedTalkgroup} name='selectedTalkgroup' onChange={handleTalkgroupChange} />
+            <Dropdown placeholder='Talkgroups' fluid multiple search selection options={talkgroupList} value={selectedTalkgroup} name='selectedTalkgroup' onChange={handleTalkgroupChange} />
           </Tab.Pane>
         )
       }


### PR DESCRIPTION
Semantic UI supports searching on their dropdown components. This is very helpful for larger systems which have a lot of talkgroups.