### PR TITLE
Save patch infomation for calls.

### DIFF
--- a/backend/controllers/calls.js
+++ b/backend/controllers/calls.js
@@ -20,6 +20,7 @@ const build_call_list = (items) => {
             srcList: item.srcList,
             star: item.star,
             freq: item.freq,
+            patches: item.patches,
             len: Math.round(item.len)
         };
         calls.push(call);
@@ -38,6 +39,7 @@ async function get_calls(query, numResults, middleDate, res) {
         time: true,
         srcList: true,
         freq: true,
+        patches: true,
         star: true,
         len: true,
         url: true

--- a/backend/controllers/uploads.js
+++ b/backend/controllers/uploads.js
@@ -108,6 +108,19 @@ exports.upload = async function (req, res, next) {
           return;
         }
 
+        patches = [];
+
+        let req_patches;
+        req_patches = req.body.patch_list;
+      
+        if(typeof req_patches != "undefined"){
+          var split_patches = req_patches.replace("[","").replace("]","").split(",");
+      
+          for (var patch in split_patches){
+            patches.push(split_patches[patch]);
+          } 
+        }
+
         let item = null;
 
         await tracer.startActiveSpan('validate_system', { parent: trace.getActiveSpan(context.active()) }, async (validateSpan) => {
@@ -178,6 +191,7 @@ exports.upload = async function (req, res, next) {
           url,
           emergency,
           path: local_path,
+          patches: patches,
           srcList,
           len: req.body.call_length ? parseFloat(req.body.call_length) : (stopTime - time) / 1000,
         });

--- a/backend/models/callSchema.js
+++ b/backend/models/callSchema.js
@@ -17,6 +17,7 @@ const callSchema = mongoose.Schema({
   emergency: Boolean,
   path: String,
   len: Number,
+  patches: [Number],
   star: {
 		type: Number,
 		default: 0

--- a/frontend/src/Call/components/CallInfoPane.js
+++ b/frontend/src/Call/components/CallInfoPane.js
@@ -22,6 +22,8 @@ function CallInfoPane(props) {
   let callDate = "-";
   let callTime = "-";
   let talkgroupNum = "-";
+  let patches = [];
+  let patchString = "";
   let header = "Call Info"
   let title = ""
   const currentCall = props.call ? props.call : false;
@@ -51,6 +53,14 @@ function CallInfoPane(props) {
     srcList = currentCall.srcList.map((source, index) => <List.Item key={index}>{source.src}[{source.pos}]</List.Item>);
     callLength = currentCall.len;
     talkgroupNum = currentCall.talkgroupNum;
+    patches = currentCall.patches;
+    
+    if(patches.length > 1) {
+      patchString = patches.join(", ");
+    }
+    else{
+      patchString = "No Patches";
+    }
 
   }
   let system = false;
@@ -102,7 +112,6 @@ function CallInfoPane(props) {
         <Statistic.Label>Talkgroup</Statistic.Label>
         <Statistic.Value>{talkgroupNum}</Statistic.Value>
       </Statistic>
-
       <List divided verticalAlign='middle'>
         <List.Item>
           <Icon name="wait" />
@@ -120,6 +129,12 @@ function CallInfoPane(props) {
           <Icon name="cubes" />
           <List.Content>
             {callFreq} MHz
+          </List.Content>
+        </List.Item>
+        <List.Item>
+          <Icon name="exchange" />
+          <List.Content>
+            {patchString}
           </List.Content>
         </List.Item>
       </List>


### PR DESCRIPTION
This adds a two small enhancements related to patches.

1. Saves the patches being sent by the OpenMHz Uploader plugin to the database.
2. Adds a small icon and patched TG info to the callInfoPane.

This should not impact playback or performance, but allows for the patch information to begin to be collected.

Example callInfoPanes:

![image](https://github.com/user-attachments/assets/7136aaa0-fcf7-466d-9bd6-2a42d4b2615c)
![image](https://github.com/user-attachments/assets/4050af84-4b9e-4256-89bd-598d93ca37f9)
